### PR TITLE
Add exception handling & stacktrace for failed commands

### DIFF
--- a/1.13CommandAPI/src/io/github/jorelali/commandapi/api/SemiReflector.java
+++ b/1.13CommandAPI/src/io/github/jorelali/commandapi/api/SemiReflector.java
@@ -356,7 +356,12 @@ public final class SemiReflector {
 			}
 			
 			//Run the code from executor and return
-			executor.run(sender, argList.toArray(new Object[argList.size()]));
+			try {
+				executor.run(sender, argList.toArray(new Object[argList.size()]));
+			} catch (Exception e) {
+				e.printStackTrace(System.out);
+				return 0;
+			}
 			return 1;
 		};
 	}


### PR DESCRIPTION
Wrote some command code that had a NullPointerException - but had no way to figure out where it was (nothing in the log, just a failed command). 

This small snippet of code dumps a stacktrace to the log when a custom command throws an exception to help with debugging. 