### PR TITLE
Override the getMessage function

### DIFF
--- a/1.13CommandAPI/src/io/github/jorelali/commandapi/api/exceptions/WrapperCommandSyntaxException.java
+++ b/1.13CommandAPI/src/io/github/jorelali/commandapi/api/exceptions/WrapperCommandSyntaxException.java
@@ -15,5 +15,10 @@ public class WrapperCommandSyntaxException extends Exception {
 	public CommandSyntaxException getException() {
 		return this.exception;
 	}
+	
+	@Override
+	public String getMessage() {
+		return getException().getMessage();
+	}
 
 }


### PR DESCRIPTION
This preserves backwards compatibility for users who were catching a CommandSyntaxException and displaying the exception message by allowing them to only swap references of CommandSyntaxException to WrapperCommandSyntaxException without further code changes.

It might be worth overriding other Throwable methods to do the same thing.