### PR TITLE
added .gitignore, changed pom.xml, improved downloadSpigot.bat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 *.iml
 build-works/
 libs/
+bin
+.classpath
+.project
+.settings
+target

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea/**
+*.iml
+build-works/
+libs/

--- a/1.13CommandAPI/.gitignore
+++ b/1.13CommandAPI/.gitignore
@@ -1,9 +1,0 @@
-bin
-libs
-.classpath
-.project
-.settings
-target
-spigotlibs/*
-.idea/
-*.iml

--- a/1.13CommandAPI/commandapi-1.13.1/pom.xml
+++ b/1.13CommandAPI/commandapi-1.13.1/pom.xml
@@ -16,6 +16,8 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
             <version>1.13.1-R0.1-SNAPSHOT</version>
+            <scope>system</scope>
+            <systemPath>${basedir}/../../libs/spigot-1.13.1.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>dev.jorel</groupId>

--- a/1.13CommandAPI/commandapi-1.13.2/pom.xml
+++ b/1.13CommandAPI/commandapi-1.13.2/pom.xml
@@ -16,6 +16,8 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
             <version>1.13.2-R0.1-SNAPSHOT</version>
+            <scope>system</scope>
+            <systemPath>${basedir}/../../libs/spigot-1.13.2.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>dev.jorel</groupId>

--- a/1.13CommandAPI/commandapi-1.13/pom.xml
+++ b/1.13CommandAPI/commandapi-1.13/pom.xml
@@ -16,6 +16,8 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
             <version>1.13-R0.1-SNAPSHOT</version>
+            <scope>system</scope>
+            <systemPath>${basedir}/../../libs/spigot-1.13.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>dev.jorel</groupId>

--- a/1.13CommandAPI/commandapi-1.14.3/pom.xml
+++ b/1.13CommandAPI/commandapi-1.14.3/pom.xml
@@ -16,6 +16,8 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
             <version>1.14.3-R0.1-SNAPSHOT</version>
+            <scope>system</scope>
+            <systemPath>${basedir}/../../libs/spigot-1.14.3.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>dev.jorel</groupId>

--- a/1.13CommandAPI/commandapi-1.14.4/pom.xml
+++ b/1.13CommandAPI/commandapi-1.14.4/pom.xml
@@ -16,6 +16,8 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
             <version>1.14.4-R0.1-SNAPSHOT</version>
+            <scope>system</scope>
+            <systemPath>${basedir}/../../libs/spigot-1.14.4.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>dev.jorel</groupId>

--- a/1.13CommandAPI/commandapi-1.14/pom.xml
+++ b/1.13CommandAPI/commandapi-1.14/pom.xml
@@ -16,6 +16,8 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
             <version>1.14.2-R0.1-SNAPSHOT</version>
+            <scope>system</scope>
+            <systemPath>${basedir}/../../libs/spigot-1.14.2.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>dev.jorel</groupId>

--- a/1.13CommandAPI/commandapi-1.15/pom.xml
+++ b/1.13CommandAPI/commandapi-1.15/pom.xml
@@ -16,6 +16,8 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
             <version>1.15-R0.1-SNAPSHOT</version>
+            <scope>system</scope>
+            <systemPath>${basedir}/../../libs/spigot-1.15.2.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>dev.jorel</groupId>

--- a/1.13CommandAPI/commandapi-1.16.1/pom.xml
+++ b/1.13CommandAPI/commandapi-1.16.1/pom.xml
@@ -16,6 +16,8 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
             <version>1.16.1-R0.1-SNAPSHOT</version>
+            <scope>system</scope>
+            <systemPath>${basedir}/../../libs/spigot-1.16.1.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>dev.jorel</groupId>

--- a/1.13CommandAPI/commandapi-core/pom.xml
+++ b/1.13CommandAPI/commandapi-core/pom.xml
@@ -16,6 +16,8 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
             <version>1.15-R0.1-SNAPSHOT</version>
+            <scope>system</scope>
+            <systemPath>${basedir}/../../libs/spigot-1.15.2.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>com.mojang</groupId>

--- a/downloadSpigot.bat
+++ b/downloadSpigot.bat
@@ -1,24 +1,45 @@
 @echo off
-if exist BuildTools.jar (
-	mkdir spigotlibs
-	if not exist spigot-1.13.jar echo Building Spigot 1.13 && java -jar BuildTools.jar --rev 1.13
-	if not exist spigot-1.13.1.jar echo Building Spigot 1.13.1 && java -jar BuildTools.jar --rev 1.13.1
-	if not exist spigot-1.13.2.jar echo Building Spigot 1.13.2 && java -jar BuildTools.jar --rev 1.13.2
-	if not exist spigot-1.14.2.jar echo Building Spigot 1.14.2 && java -jar BuildTools.jar --rev 1.14.2
-	if not exist spigot-1.14.3.jar echo Building Spigot 1.14.3 && java -jar BuildTools.jar --rev 1.14.3
-	if not exist spigot-1.14.4.jar echo Building Spigot 1.14.4 && java -jar BuildTools.jar --rev 1.14.4
-	if not exist spigot-1.15.2.jar echo Building Spigot 1.15.2 && java -jar BuildTools.jar --rev 1.15.2
-	if not exist spigot-1.16.1.jar echo Building Spigot 1.16.1 && java -jar BuildTools.jar --rev 1.16.1
+:start
+if not exist build-works (
+    mkdir build-works
+    if %ERRORLEVEL% == 0 (
+        echo Created folder: build-works
+    )
+)
+
+if not exist libs (
+    mkdir libs
+    if %ERRORLEVEL% == 0 (
+        echo Created folder: libs
+    )
+)
+
+if exist build-works\BuildTools.jar (
+	cd build-works
+	if not exist spigot-1.13.jar title Building Spigot 1.13 && java -jar BuildTools.jar --rev 1.13
+	if not exist spigot-1.13.1.jar title Building Spigot 1.13.1 && java -jar BuildTools.jar --rev 1.13.1
+	if not exist spigot-1.13.2.jar title Building Spigot 1.13.2 && java -jar BuildTools.jar --rev 1.13.2
+	if not exist spigot-1.14.2.jar title Building Spigot 1.14.2 && java -jar BuildTools.jar --rev 1.14.2
+	if not exist spigot-1.14.3.jar title Building Spigot 1.14.3 && java -jar BuildTools.jar --rev 1.14.3
+	if not exist spigot-1.14.4.jar title Building Spigot 1.14.4 && java -jar BuildTools.jar --rev 1.14.4
+	if not exist spigot-1.15.2.jar title Building Spigot 1.15.2 && java -jar BuildTools.jar --rev 1.15.2
+	if not exist spigot-1.16.1.jar title Building Spigot 1.16.1 && java -jar BuildTools.jar --rev 1.16.1
+	cd ..
 	
-	copy spigot-1.13.jar spigotlibs
-	copy spigot-1.13.1.jar spigotlibs
-	copy spigot-1.13.2.jar spigotlibs
-	copy spigot-1.14.2.jar spigotlibs
-	copy spigot-1.14.3.jar spigotlibs
-	copy spigot-1.14.4.jar spigotlibs
-	copy spigot-1.15.2.jar spigotlibs
-	copy spigot-1.16.1.jar spigotlibs
+	title Copying files
+	copy build-works\spigot-1.13.jar libs
+	copy build-works\spigot-1.13.1.jar libs
+	copy build-works\spigot-1.13.2.jar libs
+	copy build-works\spigot-1.14.2.jar libs
+	copy build-works\spigot-1.14.3.jar libs
+	copy build-works\spigot-1.14.4.jar libs
+	copy build-works\spigot-1.15.2.jar libs
+	copy build-works\spigot-1.16.1.jar libs
 	
+	title Done!
 	echo Done!
 	pause
-) else (echo BuildTool.jar not found! && pause)
+) else (
+	bitsadmin /transfer DownloadBT https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar %CD%\build-works\BuildTools.jar
+	goto start
+)


### PR DESCRIPTION
**I'm Japanese and my English is not good (I may use translations) please understand...**

Changes:
+ don't let git commit files that don't want... `(.gitignore)`
+ "org.spigotmc:spigot:1.15-R0.1-SNAPSHOT" is when run "downloadSpigot.bat", it doesn't add it to the local repository. The build fails, so I changed to a more reliable method.  `(1.13CommandAPI/commandapi-${mc-ver}/pom.xml , 1.13CommandAPI/commandapi-core/pom.xml)`
+ I changed the batch file a bit because I didn't want the garbage left in the root folder after I built Spigot. `(downloadSpigot.bat)`

Please let us know if you have any problems.
If you don't need this pull request or only need part of it, you may close it.